### PR TITLE
Fixed "login" function name

### DIFF
--- a/exploit.sh
+++ b/exploit.sh
@@ -43,7 +43,7 @@ Example: $0 http://files.ubuntu.local/index.php admin \"admin@123\"
 "
 }
 
-log-in(){
+login(){
 URL=$1
 admin=$2
 pass=$3
@@ -129,7 +129,7 @@ done
 if [ $1 ] && [ $2 ] && [ $3 ]
 then
 check
-log-in $1 $2 $3
+login $1 $2 $3
 
 find_webroot
 


### PR DESCRIPTION
The previous function name "log-in" caused the following error:
``` ./exploit.sh: 46: Syntax error: Bad function name ```